### PR TITLE
What to do when no output?

### DIFF
--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -514,6 +514,7 @@ class EventStream(Stream):
                              filled={k[0]: True for k in self.output_info},
                              seq_num=self.i)
 
+            # if output_info is not empty dict
             if self.output_info:
                 new_event.update(data={output_name: output
                                        for (output_name, desc), output in
@@ -522,11 +523,12 @@ class EventStream(Stream):
                 if outputs is None:
                     outputs = {}
                 elif not isinstance(outputs, dict):
-                    errormsg = "Error, outputs is not a dict. Can't continue"
-                    errormsg += "\n This typically comes from a function"
-                    errormsg += " whose output is not nothing or a dict."
-                    errormsg += " When dealing with such outputs, please "
-                    errormsg += "use the output_info keyword argument."
+                    print('outputs not dict! raising  a type errror')
+                    errormsg = "Error, outputs is not a dict. Can't continue\n"
+                    errormsg += "This typically comes from a function\n"
+                    errormsg += "whose output is not nothing or a dict.\n"
+                    errormsg += "When dealing with such outputs, please \n"
+                    errormsg += "use the output_info keyword argument.\n"
                     raise TypeError(errormsg)
                 new_event.update(data=outputs)
             self.i += 1

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -519,7 +519,7 @@ class EventStream(Stream):
                                        for (output_name, desc), output in
                                        zzip(self.output_info, outputs)})
             else:
-                new_event.update(data=outputs['data'])
+                new_event.update(data=outputs)
             self.i += 1
             return new_event
 

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -519,6 +519,15 @@ class EventStream(Stream):
                                        for (output_name, desc), output in
                                        zzip(self.output_info, outputs)})
             else:
+                if outputs is None:
+                    outputs = {}
+                elif not isinstance(outputs, dict):
+                    errormsg = "Error, outputs is not a dict. Can't continue"
+                    errormsg += "\n This typically comes from a function"
+                    errormsg += " whose output is not nothing or a dict."
+                    errormsg += " When dealing with such outputs, please "
+                    errormsg += "use the output_info keyword argument."
+                    raise TypeError(errormsg)
                 new_event.update(data=outputs)
             self.i += 1
             return new_event

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -1186,8 +1186,7 @@ def test_outputinfo_default(exp_db, start_uid1):
 
     raw_data = list(hdr.stream(fill=True))
     s = Stream()
-    s2 = es.map(empty_function, s, input_info={'x':'pe1_image'})
-
+    es.map(empty_function, s, input_info={'x': 'pe1_image'})
 
     # should not raise any exception
     for d in raw_data:

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -1207,7 +1207,6 @@ def test_outputinfo_default(exp_db, start_uid1):
         # events themselves
         if d[0] == 'stop':
             with pytest.raises(TypeError):
-                print("please raise me a type errorr")
                 s2.emit(d)
         else:
             s2.emit(d)

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -1176,3 +1176,19 @@ def test_curate_streams():
 
     assert doc5_curated == ('start', ({}, {}))
     assert doc5_curated2 == ('start', ({}, {}))
+
+
+def test_outputinfo_default(exp_db, start_uid1):
+    def empty_function(x):
+        return None
+
+    hdr = exp_db[start_uid1]
+
+    raw_data = list(hdr.stream(fill=True))
+    s = Stream()
+    s2 = es.map(empty_function, s, input_info={'x':'pe1_image'})
+
+
+    # should not raise any exception
+    for d in raw_data:
+        s.emit(d)


### PR DESCRIPTION
I think we need a test for the default behaviour when no `output_info` is defined.
Also, I suggest that if `output_info` is not specified, the output is treated as the data dict.

What do you think @CJ-Wright ?