### PR TITLE
BUG/TST: added curate_streams to zip + other

### DIFF
--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -250,7 +250,9 @@ class EventStream(Stream):
         else:
             names, docs = nds
             name = names
-            docs = (docs,)
+            # make sure it's a dict not tuple
+            if not isinstance(nds[1], tuple):
+                docs = (docs,)
         return name, docs
 
     def generate_provenance(self, **kwargs):
@@ -735,7 +737,7 @@ class zip(EventStream):
             tup = tuple(buf.popleft() for buf in self.buffers)
             self.condition.notify_all()
             self.prior = tup
-            return self.emit(tup)
+            return self.emit(self.curate_streams(tup))
         elif len(L) > self.maxsize:
             return self.condition.wait()
 

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -253,6 +253,17 @@ class EventStream(Stream):
             # make sure it's a dict not tuple
             if not isinstance(nds[1], tuple):
                 docs = (docs,)
+        # this is needed in case some elements of docs were a list
+        # here we assume doc is always a dict and the list of docs a tuple
+        newdocs = list()
+        for doc in docs:
+            # for case of ((name, ({}, {})), (name, ({}, {})))
+            if isinstance(doc, tuple):
+                newdocs.extend(doc)
+            else:
+                newdocs.append(doc)
+
+        docs = tuple(newdocs)
         return name, docs
 
     def generate_provenance(self, **kwargs):

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -873,13 +873,17 @@ def test_curate_streams():
 
     doc3 = (('start', {}), ('start', {}))
 
+    doc4 = (('start', {}), ('start', ({}, {})))
+
     doc1_curated = s.curate_streams(doc1)
     doc2_curated = s.curate_streams(doc2)
     doc3_curated = s.curate_streams(doc3)
+    doc4_curated = s.curate_streams(doc4)
     # try nesting
     doc1_curated2 = s.curate_streams(doc1_curated)
     doc2_curated2 = s.curate_streams(doc2_curated)
     doc3_curated2 = s.curate_streams(doc3_curated)
+    doc4_curated2 = s.curate_streams(doc4_curated)
 
     print(doc3_curated)
     assert doc1_curated == ('start', (None, ))
@@ -890,3 +894,6 @@ def test_curate_streams():
 
     assert doc3_curated == ('start', ({}, {}))
     assert doc3_curated2 == ('start', ({}, {}))
+
+    assert doc4_curated == ('start', ({}, {}, {}))
+    assert doc4_curated2 == ('start', ({}, {}, {}))

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -578,7 +578,7 @@ def test_zip(exp_db, start_uid1, start_uid3):
 
     assert_docs = set()
     for l1, l2 in L:
-        assert_docs.add(l1[0])
+        assert_docs.add(l1)
         assert l1 != l2
     for n in ['start', 'descriptor', 'event', 'stop']:
         assert n in assert_docs
@@ -862,3 +862,31 @@ def test_workflow(exp_db, start_uid1):
         assert d
     for n in ['start', 'descriptor', 'event', 'stop']:
         assert n in assert_docs
+
+
+def test_curate_streams():
+    ''' Ensure that stream curation works as intended'''
+    s = es.EventStream()
+    # try both dict and None type
+    doc1 = ('start', None)
+    doc2 = ('start', {})
+
+    doc3 = (('start', {}), ('start', {}))
+
+    doc1_curated = s.curate_streams(doc1)
+    doc2_curated = s.curate_streams(doc2)
+    doc3_curated = s.curate_streams(doc3)
+    # try nesting
+    doc1_curated2 = s.curate_streams(doc1_curated)
+    doc2_curated2 = s.curate_streams(doc2_curated)
+    doc3_curated2 = s.curate_streams(doc3_curated)
+
+    print(doc3_curated)
+    assert doc1_curated == ('start', (None, ))
+    assert doc1_curated2 == ('start', (None, ))
+
+    assert doc2_curated == ('start', ({}, ))
+    assert doc2_curated2 == ('start', ({}, ))
+
+    assert doc3_curated == ('start', ({}, {}))
+    assert doc3_curated2 == ('start', ({}, {}))


### PR DESCRIPTION
    * fixed curate_streams to work in a nested fashion
    * added a test for curate_streams intended behaviour
    * added curate_streams before emitting on zip

Discussion from #45 
Also, see tests as a point of discussion as to how `curate_streams` should behave. I made a slight line change to allow for `curate_streams(curate_streams(nds))` to work properly.