### PR TITLE
allow eventify to grab multiple attributes from start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
   - export GIT_FULL_HASH=`git rev-parse HEAD`
   - conda create --yes -n testenv numpy scipy flake8 matplotlib python=$TRAVIS_PYTHON_VERSION pytest coverage codecov pip databroker bluesky nose -c conda-forge -c lightsource2-dev -c lightsource-tag -c lightsource2 -c soft-matter
   - source activate testenv
+  - pip install https://github.com/NSLS-II/ophyd/zipball/master#egg=ophyd
   - if [[ "${CUTTING_EDGE}" == true ]]; then
       conda remove metadatastore databroker filestore bluesky event-model --yes;
       pip install https://github.com/NSLS-II/event-model/zipball/master#egg=event_model;

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1165,8 +1165,9 @@ class Eventify(EventStream):
     ----------
     child: EventStream instance
         The event stream to eventify
-    start_key: str
-        The run start key to use to create the events
+    start_keys: str, optional
+        The run start keys to use to create the events
+        If none supplied, then load all start keys into event
     output_info: list of tuples, optional
         describes the resulting stream
 
@@ -1196,8 +1197,13 @@ class Eventify(EventStream):
         EventStream.__init__(self, child, output_info=output_info, **kwargs)
 
     def start(self, docs):
-        for start_key in self.start_keys:
-            self.vals.append(docs[0][start_key])
+        if len(self.start_keys) > 0:
+            for start_key in self.start_keys:
+                self.vals.append(docs[0][start_key])
+        else:
+            start_keys = docs[0].keys()
+            for start_key in self.start_keys:
+                self.vals.append(docs[0][start_key])
 
         if len(self.output_info) == 1:
             self.vals = self.vals[0]

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1199,15 +1199,15 @@ class Eventify(EventStream):
     def start(self, docs):
         # If there are no start keys, then use all the keys
         if not self.start_keys:
-            self.start_keys = docs[0].keys()
+            self.start_keys = list(docs[0].keys())
         for start_key in self.start_keys:
             self.vals.append(docs[0][start_key])
 
-        # If no output info provided use all the keys
-        if self.output_info is None:
+        # If no output info provided use all the start keys
+        if not self.output_info:
             self.output_info = []
             for start_key in self.start_keys:
-                self.output_info.append([(start_key, start_key)])
+                self.output_info.append((start_key, start_key))
 
         return super().start(docs)
 

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1187,22 +1187,26 @@ class Eventify(EventStream):
     >>> assert len(L) == 4
     """
 
-    def __init__(self, child, start_key, *, output_info, **kwargs):
+    def __init__(self, child, *start_keys, output_info, **kwargs):
         # TODO: maybe allow start_key to be a list of relevent keys?
-        self.start_key = start_key
-        self.val = None
+        self.start_keys = start_keys
+        self.vals = list()
         self.emit_event = False
 
         EventStream.__init__(self, child, output_info=output_info, **kwargs)
 
     def start(self, docs):
-        self.val = docs[0][self.start_key]
+        for start_key in self.start_keys:
+            self.vals.append(docs[0][start_key])
+
+        if len(self.output_info) == 1:
+            self.vals = self.vals[0]
         return super().start(docs)
 
     def event(self, docs):
         if not self.emit_event:
             self.emit_event = True
-            return super().event(self.issue_event(self.val))
+            return super().event(self.issue_event(self.vals))
 
 
 class Query(EventStream):

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1188,7 +1188,7 @@ class Eventify(EventStream):
     >>> assert len(L) == 4
     """
 
-    def __init__(self, child, *start_keys, output_info, **kwargs):
+    def __init__(self, child, *start_keys, output_info=None, **kwargs):
         # TODO: maybe allow start_key to be a list of relevent keys?
         self.start_keys = start_keys
         self.vals = list()
@@ -1197,16 +1197,18 @@ class Eventify(EventStream):
         EventStream.__init__(self, child, output_info=output_info, **kwargs)
 
     def start(self, docs):
-        if len(self.start_keys) > 0:
-            for start_key in self.start_keys:
-                self.vals.append(docs[0][start_key])
-        else:
-            start_keys = docs[0].keys()
-            for start_key in self.start_keys:
-                self.vals.append(docs[0][start_key])
+        # If there are no start keys, then use all the keys
+        if not self.start_keys:
+            self.start_keys = docs[0].keys()
+        for start_key in self.start_keys:
+            self.vals.append(docs[0][start_key])
 
-        if len(self.output_info) == 1:
-            self.vals = self.vals[0]
+        # If no output info provided use all the keys
+        if self.output_info is None:
+            self.output_info = []
+            for start_key in self.start_keys:
+                self.output_info.append([(start_key, start_key)])
+
         return super().start(docs)
 
     def event(self, docs):

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -880,7 +880,7 @@ def test_eventify(exp_db, start_uid1):
         assert_docs.add(l[0])
         assert_docs2.add(l2[0])
         if l[0] == 'event':
-            assert l[1]['data']['name'] == 'test'
+            assert l[1]['data']['name'] == ['test', 'test']
             assert l2[1]['data']['name'] == 'test'
             assert l2[1]['data']['name2'] == 'test'
         if l[0] == 'stop':

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -890,6 +890,31 @@ def test_eventify(exp_db, start_uid1):
         assert n in assert_docs
 
 
+def test_eventify_all(exp_db, start_uid1):
+    source = Stream()
+
+    dp = es.Eventify(source)
+    L = dp.sink_to_list()
+    dp.sink(star(SinkAssertion(False)))
+    dp.sink(print)
+
+    ih1 = exp_db[start_uid1]
+    s = exp_db.restream(ih1, fill=True)
+    for a in s:
+        source.emit(a)
+
+    assert len(L) == 4
+    assert_docs = set()
+    for l in L:
+        assert_docs.add(l[0])
+        if l[0] == 'event':
+            assert l[1]['data']['name'] == 'test'
+        if l[0] == 'stop':
+            assert l[1]['exit_status'] == 'success'
+    for n in ['start', 'descriptor', 'event', 'stop']:
+        assert n in assert_docs
+
+
 def test_query(exp_db, start_uid1):
     source = es.EventStream()
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -848,13 +848,23 @@ def test_lossless_combine_latest_reverse(exp_db, start_uid1, start_uid3):
 def test_eventify(exp_db, start_uid1):
     source = Stream()
 
-    dp = es.Eventify(source, 'name',
+    dp = es.Eventify(source, 'name', 'name',
                      output_info=[('name', {
                          'dtype': 'str',
                          'source': 'testing'})])
+    # try two outputs
+    dp2 = es.Eventify(source, 'name', 'name',
+                     output_info=[('name', {
+                         'dtype': 'str',
+                         'source': 'testing'}),
+                         ('name2',
+                          {'dtype': 'str', 'source': 'testing'})])
     L = dp.sink_to_list()
     dp.sink(star(SinkAssertion(False)))
     dp.sink(print)
+    L2 = dp2.sink_to_list()
+    dp2.sink(star(SinkAssertion(False)))
+    dp2.sink(print)
 
     ih1 = exp_db[start_uid1]
     s = exp_db.restream(ih1, fill=True)
@@ -862,13 +872,20 @@ def test_eventify(exp_db, start_uid1):
         source.emit(a)
 
     assert len(L) == 4
+    assert len(L2) == 4
     assert_docs = set()
-    for l in L:
+    assert_docs2 = set()
+    # zip them since we know they're same length and order
+    for l, l2 in zip(L, L2):
         assert_docs.add(l[0])
+        assert_docs2.add(l2[0])
         if l[0] == 'event':
             assert l[1]['data']['name'] == 'test'
+            assert l2[1]['data']['name'] == 'test'
+            assert l2[1]['data']['name2'] == 'test'
         if l[0] == 'stop':
             assert l[1]['exit_status'] == 'success'
+            assert l2[1]['exit_status'] == 'success'
     for n in ['start', 'descriptor', 'event', 'stop']:
         assert n in assert_docs
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -854,11 +854,11 @@ def test_eventify(exp_db, start_uid1):
                          'source': 'testing'})])
     # try two outputs
     dp2 = es.Eventify(source, 'name', 'name',
-                     output_info=[('name', {
-                         'dtype': 'str',
-                         'source': 'testing'}),
-                         ('name2',
-                          {'dtype': 'str', 'source': 'testing'})])
+                      output_info=[('name', {
+                                   'dtype': 'str',
+                                   'source': 'testing'}),
+                                   ('name2',
+                                    {'dtype': 'str', 'source': 'testing'})])
     L = dp.sink_to_list()
     dp.sink(star(SinkAssertion(False)))
     dp.sink(print)


### PR DESCRIPTION
For discussion, this would be useful. One use case is when we have a stream with a `beamcenterx` and `beamcentery` attribute, for example. Another option is two eventifys plus a merge.