### PR TITLE
Filter start

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='shed',
     version='0.0.0-alpha',
-    packages=['shed'],
+    packages=find_packages(),
     # description='data processing module',
     zip_safe=False,
     url='http:/github.com/xpdAcq/shed', install_requires=['matplotlib']

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='shed',
     version='0.0.0-alpha',
-    packages=find_packages(),
+    packages=['shed'],
     # description='data processing module',
     zip_safe=False,
     url='http:/github.com/xpdAcq/shed', install_requires=['matplotlib']

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -435,7 +435,7 @@ class EventStream(Stream):
             self.outbound_descriptor_uid = None
             self.run_start_uid = None
             return 'stop', new_stop
-        elif self.raise_upon_error:
+        elif self.raise_upon_error and self.excep:
             raise self.excep
 
     def event_contents(self, docs, full_event=False):
@@ -637,6 +637,10 @@ class filter(EventStream):
     full_event: bool, optional
         If True expose the full event dict to the predicate, if False
         only expose the data from the event
+    document_name: {'event', 'start'}, optional
+        Which document to filter on, if event only pass events which meet the
+        criteria. Otherwise only pass streams where the criteria is True in
+        the start.
     **kwargs: dict
         kwargs to be passed to the function
 
@@ -653,10 +657,24 @@ class filter(EventStream):
     >>> L = m.sink_to_list()
     >>> for doc in g: z = source.emit(doc)
     >>> assert len(L) == 5
+
+    Filtering full headers
+
+    >>> from shed.utils import to_event_model
+    >>> from streamz import Stream
+    >>> import shed.event_streams as es
+    >>> a = [1, 2, 3]  # base data
+    >>> g = to_event_model(a, [('det', {'dtype': 'float'})])
+    >>> source = Stream()
+    >>> m = es.filter(es.dstar(lambda x: x>1), source, input_info={'x': 'det'})
+    >>> l = m.sink(print)
+    >>> L = m.sink_to_list()
+    >>> for doc in g: z = source.emit(doc)
+    >>> assert len(L) == 5
     """
 
     def __init__(self, predicate, child, *args, input_info,
-                 full_event=False, **kwargs):
+                 full_event=False, document_name='event', **kwargs):
         """Initialize the node
         """
         self.predicate = predicate
@@ -665,7 +683,16 @@ class filter(EventStream):
         self.kwargs = kwargs
         self.args = args
         self.full_event = full_event
+        self.document_name = document_name
         self.generate_provenance(predicate=predicate)
+
+    def start(self, docs):
+        if self.document_name == 'start':
+            # TODO: should we have something like event_contents for starts?
+            if not self.predicate(docs):
+                # if we fail the criteria don't issue any documents
+                self.bypass = True
+        super().start(docs)
 
     def event(self, doc):
         res_args, res_kwargs = self.event_contents(doc, self.full_event)

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -692,16 +692,20 @@ class filter(EventStream):
             if not self.predicate(docs):
                 # if we fail the criteria don't issue any documents
                 self.bypass = True
-        super().start(docs)
+        else:
+            super().start(docs)
 
     def event(self, doc):
-        res_args, res_kwargs = self.event_contents(doc, self.full_event)
-        try:
-            if self.predicate(*res_args, *self.args,
-                              **res_kwargs, **self.kwargs):
-                return super().event(doc[0])
-        except Exception as e:
-            return super().stop(e)
+        if self.document_name == 'event':
+            res_args, res_kwargs = self.event_contents(doc, self.full_event)
+            try:
+                if self.predicate(*res_args, *self.args,
+                                  **res_kwargs, **self.kwargs):
+                    return super().event(doc[0])
+            except Exception as e:
+                return super().stop(e)
+        else:
+            super().event(doc)
 
 
 class accumulate(EventStream):

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -1176,4 +1176,4 @@ class QueryUnpacker(EventStream):
         name, doc = x
         if name == 'event':
             return [self.emit(nd) for nd in
-                    self.db[doc['data']['hdr_uid']].stream(fill=self.fill)]
+                    self.db[doc['data']['hdr_uid']].documents(fill=self.fill)]

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -692,8 +692,10 @@ class filter(EventStream):
             if not self.predicate(docs):
                 # if we fail the criteria don't issue any documents
                 self.bypass = True
+            else:
+                return super().start(docs)
         else:
-            super().start(docs)
+            return super().start(docs)
 
     def event(self, doc):
         if self.document_name == 'event':
@@ -705,7 +707,7 @@ class filter(EventStream):
             except Exception as e:
                 return super().stop(e)
         else:
-            super().event(doc)
+            return super().event(doc)
 
 
 class accumulate(EventStream):

--- a/shed/tests/conftest.py
+++ b/shed/tests/conftest.py
@@ -63,17 +63,17 @@ def img_size():
 @pytest.fixture(scope='function')
 def exp_db(db, tmp_dir, img_size, fresh_RE):
     db2 = db
-    fs = db2.fs
-    # fs.register_handler('npy', NpyHandler)
-    fs.register_handler('RWFS_NPY', ReaderWithRegistryHandler)
+    reg = db2.reg
+    # reg.register_handler('npy', NpyHandler)
+    reg.register_handler('RWFS_NPY', ReaderWithRegistryHandler)
     RE = fresh_RE
     RE.subscribe(db.insert)
 
-    uid1 = insert_imgs(RE, fs, 5, img_size, tmp_dir,
+    uid1 = insert_imgs(RE, reg, 5, img_size, tmp_dir,
                        bt_safN=0, pi_name='chris', start_uid1=True)
-    uid2 = insert_imgs(RE, fs, 5, img_size, tmp_dir,
+    uid2 = insert_imgs(RE, reg, 5, img_size, tmp_dir,
                        pi_name='tim', bt_safN=1, start_uid2=True)
-    uid3 = insert_imgs(RE, fs, 2, img_size, tmp_dir,
+    uid3 = insert_imgs(RE, reg, 2, img_size, tmp_dir,
                        pi_name='chris', bt_safN=2, start_uid3=True)
     yield db2
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -454,6 +454,25 @@ def test_filter(exp_db, start_uid1):
         assert n in assert_docs
 
 
+def test_filter_full_header(exp_db, start_uid1):
+    source = Stream()
+
+    def f(docs):
+        d = docs[0]
+        return d['sample_name'] != 'hi'
+
+    dp = es.filter(f, source, input_info=None, document_name='start')
+    L = dp.sink_to_list()
+
+    ih1 = exp_db[start_uid1]
+    s = exp_db.restream(ih1, fill=True)
+    for a in s:
+        source.emit(a)
+
+    assert dp.bypass is True
+    assert L == []
+
+
 def test_filter_args_kwargs(exp_db, start_uid1):
     source = Stream()
 
@@ -1043,10 +1062,10 @@ def test_curate_streams():
     doc4_curated2 = s.curate_streams(doc4_curated, True)
     doc5_curated2 = s.curate_streams(doc5_curated, True)
 
-    assert doc1_curated == ('start', (None, ))
-    assert doc1_curated2 == ('start', None, )
+    assert doc1_curated == ('start', (None,))
+    assert doc1_curated2 == ('start', None,)
 
-    assert doc2_curated == ('start', ({}, ))
+    assert doc2_curated == ('start', ({},))
     assert doc2_curated2 == ('start', {})
 
     assert doc3_curated == ('start', ({}, {}))

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -461,8 +461,15 @@ def test_filter_full_header(exp_db, start_uid1):
         d = docs[0]
         return d['sample_name'] != 'hi'
 
+    def g(docs):
+        d = docs[0]
+        return d['sample_name'] == 'hi'
+
     dp = es.filter(f, source, input_info=None, document_name='start')
+    dp2 = es.filter(g, source, input_info=None, document_name='start')
+
     L = dp.sink_to_list()
+    L2 = dp2.sink_to_list()
 
     ih1 = exp_db[start_uid1]
     s = exp_db.restream(ih1, fill=True)
@@ -471,6 +478,9 @@ def test_filter_full_header(exp_db, start_uid1):
 
     assert dp.bypass is True
     assert L == []
+
+    assert dp2.bypass is False
+    assert L2 != []
 
 
 def test_filter_args_kwargs(exp_db, start_uid1):

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -993,8 +993,8 @@ def test_workflow(exp_db, start_uid1):
     hdr = exp_db[start_uid1]
 
     raw_data = list(hdr.documents(fill=True))
-    dark_data = list(exp_db[hdr['start']['sc_dk_field_uid']][
-                         0].documents(fill=True))
+    dark_data = list(
+        exp_db[hdr['start']['sc_dk_field_uid']][0].documents(fill=True))
     rds = Stream()
     dark_data_stream = Stream()
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -832,7 +832,7 @@ def test_query(exp_db, start_uid1):
         return db(uid=docs[0]['uid'])
 
     hdr = exp_db[start_uid1]
-    s = hdr.stream()
+    s = hdr.documents()
 
     dp = es.Query(exp_db, source, qf,
                   query_decider=lambda x, y: next(iter(x)))
@@ -855,7 +855,7 @@ def test_query(exp_db, start_uid1):
         assert n in assert_docs
 
     assert_docs = set()
-    for l, ll in zip(L2, hdr.stream()):
+    for l, ll in zip(L2, hdr.documents()):
         assert_docs.add(l[0])
         assert l[0] == ll[0]
         if l[0] is 'start':
@@ -992,9 +992,9 @@ def test_workflow(exp_db, start_uid1):
 
     hdr = exp_db[start_uid1]
 
-    raw_data = list(hdr.stream(fill=True))
-    dark_data = list(exp_db[hdr['start']['sc_dk_field_uid']][0].stream(
-        fill=True))
+    raw_data = list(hdr.documents()(fill=True))
+    dark_data = list(exp_db[hdr['start']['sc_dk_field_uid']][
+                         0].documents(fill=True))
     rds = Stream()
     dark_data_stream = Stream()
 

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -992,7 +992,7 @@ def test_workflow(exp_db, start_uid1):
 
     hdr = exp_db[start_uid1]
 
-    raw_data = list(hdr.documents()(fill=True))
+    raw_data = list(hdr.documents(fill=True))
     dark_data = list(exp_db[hdr['start']['sc_dk_field_uid']][
                          0].documents(fill=True))
     rds = Stream()


### PR DESCRIPTION
We want the capacity to filter entire headers based offed of their starts. This will allow us to choose between pipelines based off of the start data.
Eg
1. Get data from RunEngine
1. Inspect if data is calibration
    1. If calibration run calibration pipeline
    1. Else run other filters/pipelines

One side effect of this is that we can setup a series of filters to check that we have pipelines to analyze the data otherwise do nothing rather than trying to analyze data we don't understand