### PR TITLE
Toeventmodel addmd

### DIFF
--- a/shed/tests/test_utils.py
+++ b/shed/tests/test_utils.py
@@ -7,9 +7,11 @@ from bluesky.callbacks.core import CallbackBase
 
 def test_to_event_model():
     det = [1, 2, 3]
+    new_md = {'hello': 'world'}
+    new_md_copy = new_md.copy()
     g = to_event_model(det, [('det', {'source': 'to_event_model',
                                       'dtype': 'float'})],
-                       md={'hello': 'world'})
+                       md=new_md)
 
     class AssertCallback(CallbackBase):
         def _check(self, doc, keys):
@@ -32,6 +34,6 @@ def test_to_event_model():
 
     source = Stream()
     source.sink(star(AssertCallback()))
-    source.sink(print)
+    assert new_md == new_md_copy
     for e in g:
         source.emit(e)

--- a/shed/tests/test_utils.py
+++ b/shed/tests/test_utils.py
@@ -5,7 +5,7 @@ from ..utils import to_event_model
 from bluesky.callbacks.core import CallbackBase
 
 
-def test_to_event_model():
+def test_to_event_model_md():
     det = [1, 2, 3]
     new_md = {'hello': 'world'}
     new_md_copy = new_md.copy()
@@ -35,5 +35,35 @@ def test_to_event_model():
     source = Stream()
     source.sink(star(AssertCallback()))
     assert new_md == new_md_copy
+    for e in g:
+        source.emit(e)
+
+
+def test_to_event_model_no_md():
+    det = [1, 2, 3]
+    g = to_event_model(det, [('det', {'source': 'to_event_model',
+                                      'dtype': 'float'})],
+                       )
+
+    class AssertCallback(CallbackBase):
+        def _check(self, doc, keys):
+            assert all([k in doc.keys() for k in keys])
+
+        def start(self, doc):
+            self._check(doc, ['uid', 'time', 'source'])
+
+        def descriptor(self, doc):
+            self._check(doc, ['uid', 'data_keys', ])
+
+        def event(self, doc):
+            self._check(doc, ['uid', 'time', 'timestamps', 'descriptor',
+                              'filled', 'seq_num'])
+
+        def stop(self, doc):
+            self._check(doc, ['exit_status', 'uid', 'provenance'])
+            assert doc['exit_status'] == 'success'
+
+    source = Stream()
+    source.sink(star(AssertCallback()))
     for e in g:
         source.emit(e)

--- a/shed/tests/test_utils.py
+++ b/shed/tests/test_utils.py
@@ -8,14 +8,16 @@ from bluesky.callbacks.core import CallbackBase
 def test_to_event_model():
     det = [1, 2, 3]
     g = to_event_model(det, [('det', {'source': 'to_event_model',
-                                      'dtype': 'float'})])
+                                      'dtype': 'float'})],
+                       md={'hello': 'world'})
 
     class AssertCallback(CallbackBase):
         def _check(self, doc, keys):
             assert all([k in doc.keys() for k in keys])
 
         def start(self, doc):
-            self._check(doc, ['uid', 'time', 'source'])
+            self._check(doc, ['uid', 'time', 'source', 'hello'])
+            assert doc.get('hello', False) == 'world'
 
         def descriptor(self, doc):
             self._check(doc, ['uid', 'data_keys', ])

--- a/shed/utils.py
+++ b/shed/utils.py
@@ -27,6 +27,8 @@ def to_event_model(data, output_info, md=None):
     """
     if md is None:
         md = {}
+    else:
+        md = md.copy()
     # add some metadata
     md.update({'source': 'to_event_model'})
     es = EventStream(md=md, output_info=output_info)

--- a/shed/utils.py
+++ b/shed/utils.py
@@ -1,7 +1,7 @@
 from .event_streams import EventStream
 
 
-def to_event_model(data, output_info, md={}):
+def to_event_model(data, output_info, md=None):
     """Take an iterable of data and put it into the event model
 
     Parameters
@@ -25,9 +25,11 @@ def to_event_model(data, output_info, md={}):
     -----
     This is only for demonstration/example use, do not use for production.
     """
-    es = EventStream(md={'source': 'to_event_model'}, output_info=output_info)
+    if md is None:
+        md = {}
     # add some metadata
-    es.md = md
+    md.update({'source': 'to_event_model'})
+    es = EventStream(md=md, output_info=output_info)
 
     yield es.dispatch(('start', None))
     yield es.dispatch(('descriptor', None))

--- a/shed/utils.py
+++ b/shed/utils.py
@@ -1,7 +1,7 @@
 from .event_streams import EventStream
 
 
-def to_event_model(data, output_info, md):
+def to_event_model(data, output_info, md={}):
     """Take an iterable of data and put it into the event model
 
     Parameters

--- a/shed/utils.py
+++ b/shed/utils.py
@@ -1,7 +1,7 @@
 from .event_streams import EventStream
 
 
-def to_event_model(data, output_info):
+def to_event_model(data, output_info, md):
     """Take an iterable of data and put it into the event model
 
     Parameters
@@ -10,6 +10,8 @@ def to_event_model(data, output_info):
         The data to be inserted
     output_info: list of tuple
         The name of the data and information to put into the descriptor
+    md : iterable of dicts
+        an iterable of dictionaries to use as metadata for the start documents
 
 
     Yields
@@ -24,6 +26,9 @@ def to_event_model(data, output_info):
     This is only for demonstration/example use, do not use for production.
     """
     es = EventStream(md={'source': 'to_event_model'}, output_info=output_info)
+    # add some metadata
+    es.md = md
+
     yield es.dispatch(('start', None))
     yield es.dispatch(('descriptor', None))
     for d in data:


### PR DESCRIPTION
this is more behind the scenes. allow the event stream simulator `to_event_model` to also add in metadata. For ex:
```python
    # simulate the data
    from shed.utils import to_event_model
    Ndata = 2
    width = 10
    height = 10
    data = np.random.random((Ndata, width, height))
    output_info = (('data', {'dtype' : 'array'}),)
    # some metadata
    md = {'sample_name' : "AgBH"}
    stream = to_event_model(data, output_info=output_info, md=md)
```

where the change is now the last two lines, where `md` may be added.