### PR TITLE
Added input_info checking on accumulate

### DIFF
--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -954,7 +954,6 @@ class accumulate(EventStream):
             self.state = {}
             # Note that there is only one input_info key allowed for this
             # stream function so this works
-
             self.state = data[next(iter(self.input_info.keys()))]
         # in case we need a bit more flexibility eg lambda x: np.empty(x.shape)
         elif hasattr(self.state, '__call__'):

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -927,6 +927,8 @@ class accumulate(EventStream):
         self.state = start
         EventStream.__init__(self, child, input_info=input_info,
                              output_info=output_info)
+        if len(input_info) != 1:
+            raise ValueError("Error : only one key allowed for accumulate")
         self.full_event = full_event
         if not across_start:
             self.start = self._not_across_start_start
@@ -952,6 +954,7 @@ class accumulate(EventStream):
             self.state = {}
             # Note that there is only one input_info key allowed for this
             # stream function so this works
+
             self.state = data[next(iter(self.input_info.keys()))]
         # in case we need a bit more flexibility eg lambda x: np.empty(x.shape)
         elif hasattr(self.state, '__call__'):

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -876,20 +876,13 @@ def test_scan_fail_input_info(exp_db, start_uid1):
     def add(img1, img2):
         return img1 + img2
 
-    dp = es.accumulate(dstar(add), source,
-                       state_key='i',
-                       input_info={'i': 'pe1_image', 'i2': 'pe2_image'},
-                       output_info=[('img', {
-                           'dtype': 'array',
-                           'source': 'testing'})])
-    sa = SinkAssertion()
-    sa.expected_docs = {'start', 'descriptor', 'event', 'stop'}
-    dp.sink(star(sa))
-
-    ih1 = exp_db[start_uid1]
-    s = exp_db.restream(ih1, fill=True)
-    for a in s:
-        source.emit(a)
+    # just test this raises ValueError
+    es.accumulate(dstar(add), source,
+                  state_key='i',
+                  input_info={'i': 'pe1_image', 'i2': 'pe2_image'},
+                  output_info=[('img', {
+                               'dtype': 'array',
+                               'source': 'testing'})])
 
 
 def test_scan_start_func(exp_db, start_uid1):

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -849,8 +849,10 @@ def test_scan(exp_db, start_uid1):
 def test_scan_fail(exp_db, start_uid1):
     source = Stream()
 
-    # some dummy function
-    dp = es.accumulate(dstar(lambda a, b : a), source,
+    def add(img1, img2):
+        return img1 + img2
+
+    dp = es.accumulate(dstar(add), source,
                        state_key='i',
                        input_info={'i': 'pe1_image'},
                        output_info=[('img', {
@@ -871,11 +873,8 @@ def test_scan_fail_input_info(exp_db, start_uid1):
     ''' should fail on bad input info (more than one input).'''
     source = Stream()
 
-    def add(img1, img2):
-        return img1 + img2
-
     # just test this raises ValueError
-    es.accumulate(dstar(add), source,
+    es.accumulate(dstar(lambda x: x), source,
                   state_key='i',
                   input_info={'i': 'pe1_image', 'i2': 'pe2_image'},
                   output_info=[('img', {

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -849,10 +849,8 @@ def test_scan(exp_db, start_uid1):
 def test_scan_fail(exp_db, start_uid1):
     source = Stream()
 
-    def add(img1, img2):
-        return img1 + img2
-
-    dp = es.accumulate(dstar(add), source,
+    # some dummy function
+    dp = es.accumulate(dstar(lambda a, b : a), source,
                        state_key='i',
                        input_info={'i': 'pe1_image'},
                        output_info=[('img', {

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -868,6 +868,30 @@ def test_scan_fail(exp_db, start_uid1):
         source.emit(a)
 
 
+@pytest.mark.xfail(raises=ValueError)
+def test_scan_fail_input_info(exp_db, start_uid1):
+    ''' should fail on bad input info (more than one input).'''
+    source = Stream()
+
+    def add(img1, img2):
+        return img1 + img2
+
+    dp = es.accumulate(dstar(add), source,
+                       state_key='i',
+                       input_info={'i': 'pe1_image', 'i2': 'pe2_image'},
+                       output_info=[('img', {
+                           'dtype': 'array',
+                           'source': 'testing'})])
+    sa = SinkAssertion()
+    sa.expected_docs = {'start', 'descriptor', 'event', 'stop'}
+    dp.sink(star(sa))
+
+    ih1 = exp_db[start_uid1]
+    s = exp_db.restream(ih1, fill=True)
+    for a in s:
+        source.emit(a)
+
+
 def test_scan_start_func(exp_db, start_uid1):
     source = Stream()
 


### PR DESCRIPTION
Add a quick check to ensure that `input_info` only contains one argument (since `accumulate` only accepts one argument).

This is done after the `super().__init__()` call so that it will also check that the default behaviour (in case `input_info` not defined) is also correct.