### PR TITLE
API : Remove need for dstar on accumulate arguments

### DIFF
--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -935,6 +935,8 @@ class accumulate(EventStream):
                              output_info=output_info)
         if input_info is not None and len(input_info) != 1:
             raise ValueError("Error : only one key allowed for accumulate")
+        # only one input expected
+        self.input_key = list(self.input_info)[0]
         self.full_event = full_event
         if not across_start:
             self.start = self._not_across_start_start
@@ -967,7 +969,7 @@ class accumulate(EventStream):
         else:
             data[self.state_key] = self.state
             try:
-                result = self.func(**data)
+                result = self.func(data[self.state_key], data[self.input_key])
             except Exception as e:
                 return super().stop(e)
             self.state = result

--- a/shed/event_streams.py
+++ b/shed/event_streams.py
@@ -967,7 +967,7 @@ class accumulate(EventStream):
         else:
             data[self.state_key] = self.state
             try:
-                result = self.func(data)
+                result = self.func(**data)
             except Exception as e:
                 return super().stop(e)
             self.state = result

--- a/shed/tests/test_streams.py
+++ b/shed/tests/test_streams.py
@@ -815,7 +815,7 @@ def test_scan(exp_db, start_uid1):
     def add(img1, img2):
         return img1 + img2
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        state_key='img1',
                        input_info={'img2': 'pe1_image'},
                        output_info=[('img', {
@@ -852,7 +852,7 @@ def test_scan_fail(exp_db, start_uid1):
     def add(img1, img2):
         return img1 + img2
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        state_key='i',
                        input_info={'i': 'pe1_image'},
                        output_info=[('img', {
@@ -891,7 +891,7 @@ def test_scan_start_func(exp_db, start_uid1):
     def get_array(img2):
         return img2
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        start=dstar(get_array),
                        state_key='img1',
                        input_info={'img2': 'pe1_image'},
@@ -928,7 +928,7 @@ def test_scan_full_event(exp_db, start_uid1):
     def add(i, j):
         return i + j
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        state_key='i',
                        input_info={'j': 'seq_num'},
                        output_info=[('total', {
@@ -966,7 +966,7 @@ def test_scan_multi_header_False(exp_db, start_uid1):
     def add(img1, img2):
         return img1 + img2
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        state_key='img1',
                        input_info={'img2': 'pe1_image'},
                        output_info=[('img', {
@@ -1021,7 +1021,7 @@ def test_scan_multi_header_True(exp_db, start_uid1):
     def add(img1, img2):
         return img1 + img2
 
-    dp = es.accumulate(dstar(add), source,
+    dp = es.accumulate(add, source,
                        state_key='img1',
                        input_info={'img2': 'pe1_image'},
                        output_info=[('img', {


### PR DESCRIPTION
This is an API change, see tests. Basically, we should run:
```
dp = es.accumulate(add, source,...
```

and not:
```
dp = es.accumulate(dstar(add), source, ...
```

this makes `accumulate` then consistent with `map`.