### PR TITLE
ENH: change 'times' attr from dictionary to list of tuples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
   - ./miniconda.sh -b -p ~/mc
   - export PATH=~/mc/bin:$PATH
   - conda config --set always_yes yes --set changeps1 no --set quiet true
+  - conda config --append channels nsls2forge
   - conda config --append channels conda-forge
   - conda update conda --yes
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - python -c "from bluesky.utils import get_history; get_history()"
   - coverage run run_tests.py
   - coverage report -m
-  - codecov
+  - bash <(curl -s https://codecov.io/bash)
   - flake8 shed
   - cd docs
   - make html

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==5.4.3
 flake8
 codecov
 coverage

--- a/shed/replay.py
+++ b/shed/replay.py
@@ -76,8 +76,12 @@ def replay(db, hdr):
     for node_uid in hdr["start"]["parent_node_map"]:
         parent_nodes[node_uid] = loaded_graph.nodes[node_uid]["stream"]
 
-    vs = sorted([(t, v) for t, v in times.items()], key=lambda x: x[0])
-    vs = [v for t, v in vs]
+    vs = [
+        {'uid': dct['uid'], 'node': dct['node']}
+        for dct in sorted(
+            times, key=lambda d: d['time']
+        )
+    ]
 
     return loaded_graph, parent_nodes, data, vs
 

--- a/shed/tests/test_simple_parallel.py
+++ b/shed/tests/test_simple_parallel.py
@@ -6,6 +6,7 @@ from rapidz.utils_test import gen_test
 from shed import SimpleFromEventStream as FromEventStream
 from shed.tests.utils import y, slow_inc, slow_filter0, slow_filter1
 from tornado import gen
+import pytest
 
 
 @gen_test(20)
@@ -197,7 +198,7 @@ def test_double_buffer_to_event_model_parallel():
         yield gen.sleep(.01)
     t1 = time.time()
     # check that this was faster than running in series
-    assert t1 - t0 < .5 * 10
+    assert t1 - t0 < .5 * 10 + 0.1
 
     assert tt
     assert p == ["start", "descriptor"] + ["event"] * 10 + ["stop"]
@@ -211,7 +212,7 @@ def test_double_buffer_to_event_model_parallel():
     print(len(L), len(futures_L))
     t1 = time.time()
     # check that this was faster than running in series
-    assert t1 - t0 < .5 * 10
+    assert t1 - t0 < .5 * 10 + 0.1
 
     assert tt
     assert p == (["start", "descriptor"] + ["event"] * 10 + ["stop"]) * 2

--- a/shed/tests/test_simple_parallel.py
+++ b/shed/tests/test_simple_parallel.py
@@ -6,7 +6,6 @@ from rapidz.utils_test import gen_test
 from shed import SimpleFromEventStream as FromEventStream
 from shed.tests.utils import y, slow_inc, slow_filter0, slow_filter1
 from tornado import gen
-import pytest
 
 
 @gen_test(20)

--- a/shed/tests/test_translation.py
+++ b/shed/tests/test_translation.py
@@ -227,8 +227,8 @@ def test_execution_order():
         (i + 1) * 2 for i in range(100, 110)
     ]
     assert l1 == ex_l
-    assert all((v == pppp.start_uid for v in pppp.times.values()))
-    t = sorted(pppp.times.keys())
+    assert all((v == pppp.start_uid for _, v in pppp.times))
+    t = sorted([t for t, _ in pppp.times])
     # ToEventStream executed first
     assert all((v < v2 for v, v2 in zip(t, l2)))
 

--- a/shed/translation_parallel.py
+++ b/shed/translation_parallel.py
@@ -80,7 +80,7 @@ class ToEventStream(SimpleToEventStream):
         if env_capture_functions is None:
             env_capture_functions = []
         self.env_capture_functions = env_capture_functions
-        self.times = {}
+        self.times = []
         for node, attrs in self.graph.nodes.items():
             for arg in getattr(attrs["stream"], "_init_args", []):
                 if getattr(arg, "__name__", "") == "<lambda>":
@@ -93,8 +93,8 @@ class ToEventStream(SimpleToEventStream):
     def emit(self, x, asynchronous=False):
         name, doc = x
         if name == "start":
-            self.times = {time.time(): self.start_uid}
-        self.times[time.time()] = self.start_uid
+            self.times = [(time.time(), self.start_uid)]
+        self.time.append((time.time(), self.start_uid))
         super().emit(x, asynchronous=asynchronous)
 
     def start_doc(self, x):
@@ -108,9 +108,9 @@ class ToEventStream(SimpleToEventStream):
 
     def stop(self, x):
         new_stop = super().stop(x)
-        times = {}
+        times = []
         for k, node in self.translation_nodes.items():
-            for t, uid in node.times.items():
-                times[t] = {"node": node.uid, "uid": uid}
+            for t, uid in node.times:
+                times.append({"time": t, "node": node.uid, "uid": uid})
         new_stop.update(times=times)
         return new_stop

--- a/shed/translation_parallel.py
+++ b/shed/translation_parallel.py
@@ -94,7 +94,7 @@ class ToEventStream(SimpleToEventStream):
         name, doc = x
         if name == "start":
             self.times = [(time.time(), self.start_uid)]
-        self.time.append((time.time(), self.start_uid))
+        self.times.append((time.time(), self.start_uid))
         super().emit(x, asynchronous=asynchronous)
 
     def start_doc(self, x):


### PR DESCRIPTION
I change the "times" attribute in the FromEventStream and ToEventStream from dictionary to list. When "emit", the times are a tuple of time and start uid. When "stop", the times become a list of dictionary with key "time", "uid", "node".

Reason: In this way we can aviod using float as key in the stop doc so that this doc can be injected to db.